### PR TITLE
Update archive.today URL from ?run=1&url= to /submit/?url=

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 
 <h3>Archive bookmarklet</h3>
 <p>For just basic archive.today functionality, you can drag this bookmarklet
-<a href="javascript:void(open('https://archive.today/?run=1&url=%27+encodeURIComponent(document.location)))">
+<a href="javascript:void(open('https://archive.today/submit/?url=%27+encodeURIComponent(document.location)))">
 <strong>Archive</strong></a> to your Favorites toolbar.<br />
 (If your Favorites toolbar is not visible, see
 <a href="https://www.androidauthority.com/show-hide-bookmarks-toolbar-3257960/" target="_blank">How to show or hide your browser's bookmarks toolbar</a>)<br />

--- a/src/Chrome/service_worker.js
+++ b/src/Chrome/service_worker.js
@@ -7,7 +7,7 @@
 // Options to control activation of new archive.today tabs (archive & search)
 // Options saved in sync, not local.
 
-const URLA = 'https://archive.today/?run=1&url=';   // URL to invoke archive.today
+const URLA = 'https://archive.today/submit/?url=';   // URL to invoke archive.today
 const URLS = 'https://archive.today/search/?q='     // URL to search archive.today
 
 // Archive page URL

--- a/src/Edge/service_worker.js
+++ b/src/Edge/service_worker.js
@@ -7,7 +7,7 @@
 // Options to control activation of new archive.today tabs (archive & search)
 // Options saved in sync, not local.
 
-const URLA = 'https://archive.today/?run=1&url=';   // URL to invoke archive.today
+const URLA = 'https://archive.today/submit/?url=';   // URL to invoke archive.today
 const URLS = 'https://archive.today/search/?q='     // URL to search archive.today
 
 // Archive page URL

--- a/src/Firefox/background.js
+++ b/src/Firefox/background.js
@@ -7,7 +7,7 @@
 // Options to control activation of new archive.today tabs (archive & search)
 // For Firefox, options saved in local, not sync!
 
-const URLA = 'https://archive.today/?run=1&url='; // URL to invoke archive.today
+const URLA = 'https://archive.today/submit/?url='; // URL to invoke archive.today
 const URLS = 'https://archive.today/search/?q=' // URL to search archive.today
 
 // Archive page URL


### PR DESCRIPTION
The archive.today/archive.ph site has changed its API/url for automatic archiving. Previously, ?run=1&url= would automatically go to the archived page, but this no longer works (now it just goes to archive.today and fills the url in the save box but doesn't submit the request automatically). The new `/submit/?url=` endpoint/url seems to now provide the same functionality.